### PR TITLE
Do not build external-table extension for Cloudberry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           submodules: true
 
       - name: (restore) database deb files caching
-        id: cache-debs
+        id: cache-debs-db
         uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
@@ -119,7 +119,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.target.db-cache-key-sfx }}-${{ steps.get-date.outputs.week }}
 
       - name: (restore) PXF deb files caching
-        id: cache-debs
+        id: cache-debs-pxf
         uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,10 @@ jobs:
         target: # make targets
           - pxf: 'deb-pxf6-gpdb-bionic'
             db-cache-key-sfx: 'deb-gpdb-bionic'
-            experimental: false
           - pxf: 'deb-pxf6-gpdb-jammy'
             db-cache-key-sfx: 'deb-gpdb-jammy'
-            experimental: false
           - pxf: 'deb-pxf6-cbdb-jammy'
             db-cache-key-sfx: 'deb-cbdb-jammy'
-            experimental: true
     steps:
       - name: Get Date
         id: get-date
@@ -98,13 +95,10 @@ jobs:
         target:
           - pxf: 'deb-pxf6-gpdb-bionic'
             db-cache-key-sfx: 'deb-gpdb-bionic'
-            experimental: false
           - pxf: 'deb-pxf6-gpdb-jammy'
             db-cache-key-sfx: 'deb-gpdb-jammy'
-            experimental: false
           - pxf: 'deb-pxf6-cbdb-jammy'
             db-cache-key-sfx: 'deb-cbdb-jammy'
-            experimental: true
     steps:
       - name: Get Date
         id: get-date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
         id: cache-debs
         uses: actions/cache@v4
         with:
-          path: |
-            ./downloads/*.deb
-            ./downloads/*.tar.gz
+          path: ./downloads/*.deb
           # save per-os with 7 days TTL
           key: ${{ runner.os }}-${{ matrix.target }}-${{ steps.get-date.outputs.week }}
 
@@ -69,9 +67,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
-          path: |
-            ./downloads/*.deb
-            ./downloads/*.tar.gz
+          path: ./downloads/*.deb
           key: ${{ runner.os }}-${{ matrix.target.db-cache-key-sfx }}-${{ steps.get-date.outputs.week }}
 
       - name: Build PXF6
@@ -81,12 +77,11 @@ jobs:
         uses: actions/cache/save@v4
         id: cache
         with:
-            path: |
-              ./downloads/*pxf*.deb
+            path: ./downloads/*pxf*.deb
             key: ${{ runner.os }}-${{ matrix.target.pxf }}-${{ github.sha }}
 
   use_pxf_debs:
-    name: Build PXF Debian Packages
+    name: Use PXF Debian Packages
     runs-on: ubuntu-latest
     needs: [build_pxf_debs]
     strategy:
@@ -114,8 +109,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
-          path: |
-            ./downloads/*.deb
+          path: ./downloads/*.deb
           key: ${{ runner.os }}-${{ matrix.target.db-cache-key-sfx }}-${{ steps.get-date.outputs.week }}
 
       - name: (restore) PXF deb files caching
@@ -123,9 +117,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
-          path: |
-            ./downloads/*.deb
-            ./downloads/*.tar.gz
+          path: ./downloads/*pxf*.deb
           key: ${{ runner.os }}-${{ matrix.target.pxf }}-${{ github.sha }}
 
       - name: Use PXF builds

--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,15 @@ ifndef PGXS
 endif
 include $(PGXS)
 
-# variables that control whether the external-table extension will be built and packaged,
+# variables that control whether the FDW/external-table extension will be built and packaged,
 # if left empty there is no skipping, otherwise a value should contain a reason for skipping
 ifeq ($(shell test $(GP_MAJORVERSION) -ne 6; echo $$?),0)
 	SKIP_EXTERNAL_TABLE_BUILD_REASON := "Cloudberry $(GP_MAJORVERSION) doesnt support External Table Framework"
 	SKIP_EXTERNAL_TABLE_PACKAGE_REASON := "Cloudberry $(GP_MAJORVERSION) doesnt support External Table Framework"
+	SKIP_FDW_BUILD_REASON := "Cloudberry $(GP_MAJORVERSION) has FDW bundled with cloudbery-db"
+	SKIP_FDW_PACKAGE_REASON := "Cloudberry $(GP_MAJORVERSION) has FDW bundled with cloudbery-db"
 endif
-# variables that control whether the FDW extension will be built and packaged,
-# if left empty there is no skipping, otherwise a value should contain a reason for skipping
-ifeq ($(shell test $(GP_MAJORVERSION) -lt 6; echo $$?),0)
-	SKIP_FDW_BUILD_REASON := "GPDB version $(GP_MAJORVERSION) is less than 6."
-endif
-ifeq ($(shell test $(GP_MAJORVERSION) -lt 7; echo $$?),0)
+ifeq ($(shell test $(GP_MAJORVERSION) -eq 6; echo $$?),0)
 	SKIP_FDW_PACKAGE_REASON := "GPDB version $(GP_MAJORVERSION) is less than 7."
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ include $(PGXS)
 # variables that control whether the external-table extension will be built and packaged,
 # if left empty there is no skipping, otherwise a value should contain a reason for skipping
 ifeq ($(shell test $(GP_MAJORVERSION) -ne 6; echo $$?),0)
-	SKIP_EXTERNAL_TABLE_BUILD_REASON := "Cloudberry $(GP_MAJORVERSION) doesn't support External Table Framework"
-	SKIP_EXTERNAL_TABLE_PACKAGE_REASON := "Cloudberry $(GP_MAJORVERSION) doesn't support External Table Framework"
+	SKIP_EXTERNAL_TABLE_BUILD_REASON := "Cloudberry $(GP_MAJORVERSION) doesnt support External Table Framework"
+	SKIP_EXTERNAL_TABLE_PACKAGE_REASON := "Cloudberry $(GP_MAJORVERSION) doesnt support External Table Framework"
 endif
 # variables that control whether the FDW extension will be built and packaged,
 # if left empty there is no skipping, otherwise a value should contain a reason for skipping
@@ -75,6 +75,7 @@ endif
 cli server:
 	@echo "===> Compiling [$@] module <==="
 	make -C $@
+
 clean:
 	rm -rf build
 	set -e ;\

--- a/package/cbdb_jammy/Dockerfile
+++ b/package/cbdb_jammy/Dockerfile
@@ -53,6 +53,5 @@ RUN dpkg-buildpackage -us -uc
 # /greenplum-db-cb_1.0.0.tar.xz
 
 RUN mkdir /build && \
-    cp /*.deb /build && \
-    cp /*.tar.* /build
+    cp /*.deb /build
 

--- a/package/gpdb_bionic/Dockerfile
+++ b/package/gpdb_bionic/Dockerfile
@@ -63,5 +63,4 @@ RUN /pxf_src/devops/scripts/build-deb.sh
 # /greenplum-db-cb_1.0.0.tar.xz
 
 RUN mkdir /build && \
-    cp /*.deb /build && \
-    cp /*.tar.* /build
+    cp /*.deb /build

--- a/package/gpdb_jammy/Dockerfile
+++ b/package/gpdb_jammy/Dockerfile
@@ -59,5 +59,4 @@ RUN /pxf_src/devops/scripts/build-deb.sh
 # /greenplum-db-cb_1.0.0.tar.xz
 
 RUN mkdir /build && \
-    cp /*.deb /build && \
-    cp /*.tar.* /build
+    cp /*.deb /build

--- a/package/pxf_6_bionic/Dockerfile
+++ b/package/pxf_6_bionic/Dockerfile
@@ -50,5 +50,4 @@ RUN source /opt/greenplum-db-6/greenplum_path.sh \
 # get your packages in
 # /greenplum-pxf-6_6.10.1_amd64.deb
 RUN mkdir /build && \
-    cp /*.deb /build && \
-    cp /*.tar.* /build
+    cp /*.deb /build

--- a/package/pxf_6_jammy/Dockerfile
+++ b/package/pxf_6_jammy/Dockerfile
@@ -49,5 +49,4 @@ RUN source /opt/greenplum-db-6/greenplum_path.sh \
 # get your packages in
 # /greenplum-pxf-6_6.10.1_amd64.deb
 RUN mkdir /build && \
-    cp /*.deb /build && \
-    cp /*.tar.* /build
+    cp /*.deb /build

--- a/package/pxf_cb_jammy/Dockerfile
+++ b/package/pxf_cb_jammy/Dockerfile
@@ -52,5 +52,4 @@ RUN source /usr/cloudberry-db/greenplum_path.sh \
 # get your packages in
 # /greenplum-pxf-1_6.10.1_amd64.deb
 RUN mkdir /build && \
-    cp /*.deb /build && \
-    cp /*.tar.* /build
+    cp /*.deb /build


### PR DESCRIPTION
This PR consists of 2 changes:
1. remove `external-table` from cloudberry build as it seems not supported by Greenplum-7 / Cloudberry:
   > PXF uses the External Table Framework in Greenplum 5 and 6 to access external data. Greenplum 6 introduces the Foreign Data Wrapper Framework to access external data, and extensions are starting to move to the foreign data wrapper (FDW) framework because the External Table Framework will be deprecated in later versions of Greenplum.
2. remove `FDW` from cloudberry build as it embeded into [`cloudberry/gpcontrib/pxf_fdw`](https://github.com/apache/cloudberry/tree/main/gpcontrib/pxf_fdw)
3. do not extract `*.tar.xz` - we don't use it... but files are really heavay