### PR TITLE
Use fresh paths from open-gpdb/gpdb-devops

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -32,7 +32,7 @@ We use docker as clean build environment. Build is consists of two stages:
 `mk-build-deps` install build dependencies from debian/control file
 `dpkg-buildpackage -us -uc` - build debian package (`-uc -us` - without signing)
 basically it will call `make <step>` from debian/rules file
-Resulitng deb files conists of:
+Resulting deb files consists of:
 * files that `make install` from debian/rules copied to `$(DESTDIR)`
 * files mentioned in debian/install
 

--- a/package/gpdb_bionic/Dockerfile
+++ b/package/gpdb_bionic/Dockerfile
@@ -27,7 +27,7 @@ COPY . /pxf_src/
 RUN mk-build-deps --build-dep \
     --install \
     --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' \
-    /pxf_src/devops/packaging/deb/gpdb_bionic/debian/control
+    /pxf_src/devops/packaging/open-gpdb/deb/18.04/control
 
 # install missing parts
 RUN tar -xzf /pxf_src/downloads/xerces-c-3.1.1.tar.gz && \
@@ -36,7 +36,8 @@ RUN tar -xzf /pxf_src/downloads/xerces-c-3.1.1.tar.gz && \
     make -j$(nproc) > /dev/null && \
     make -j$(nproc) install
 
-RUN cp -r /pxf_src/devops/packaging/deb/gpdb_bionic/debian /gpdb_src/
+RUN mkdir -p /gpdb_src/debian && \
+    cp -r /pxf_src/devops/packaging/open-gpdb/deb/18.04/* /gpdb_src/debian
 
 RUN chmod +x /pxf_src/devops/build_automation/gpdb/scripts/configure-gpdb.sh && \
     chmod +x /pxf_src/devops/build_automation/gpdb/scripts/build-gpdb.sh && \

--- a/package/gpdb_jammy/Dockerfile
+++ b/package/gpdb_jammy/Dockerfile
@@ -29,7 +29,7 @@ COPY . /pxf_src/
 RUN mk-build-deps --build-dep \
     --install \
     --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' \
-    /pxf_src/devops/packaging/deb/jammy/debian/control
+    /pxf_src/devops/packaging/open-gpdb/deb/22.04/control
 
 # install missing parts
 RUN tar -xzf /pxf_src/downloads/xerces-c-3.1.1.tar.gz && \
@@ -38,8 +38,8 @@ RUN tar -xzf /pxf_src/downloads/xerces-c-3.1.1.tar.gz && \
     make -j$(nproc) > /dev/null && \
     make -j$(nproc) install
 
-# FIXME: rename folder in upstream!
-RUN cp -r /pxf_src/devops/packaging/deb/jammy/debian /gpdb_src/
+RUN mkdir -p /gpdb_src/debian && \
+    cp -r /pxf_src/devops/packaging/open-gpdb/deb/22.04/* /gpdb_src/debian
 
 RUN chmod +x /pxf_src/devops/build_automation/gpdb/scripts/configure-gpdb.sh && \
     chmod +x /pxf_src/devops/build_automation/gpdb/scripts/build-gpdb.sh && \

--- a/package/pxf_6_bionic/Dockerfile
+++ b/package/pxf_6_bionic/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update &&\
         python3 devscripts debhelper pbuilder reprepro equivs quilt
 
 # Install golang
-RUN wget -O - "https://go.dev/dl/go1.22.9.linux-amd64.tar.gz" | tar -C /usr/local -xz
+RUN wget -O - "https://go.dev/dl/go1.22.12.linux-amd64.tar.gz" | tar -C /usr/local -xz
 
 COPY . /pxf_src/
 RUN apt -o Apt::Get::Assume-Yes=true install /pxf_src/downloads/greenplum-db-6_6.0.0-bionic-dev_amd64.deb
@@ -26,7 +26,8 @@ RUN locale-gen en_US.utf8
 
 # copy source & create layout for packaging
 ENV PXF_PKG_VERSION "6.10.1-bionic-dev"
-RUN cp -r /pxf_src/devops/packaging/deb/pxf_6_bionic/debian /pxf_src/debian \
+RUN mkdir -p /pxf_src/debian \
+ && cp -r /pxf_src/devops/packaging/pxf/deb/18.04/* /pxf_src/debian \
  && source /pxf_src/package/package-deb.bash \
  && print_changelog > /pxf_src/debian/changelog
 

--- a/package/pxf_6_jammy/Dockerfile
+++ b/package/pxf_6_jammy/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
         python3 devscripts debhelper pbuilder reprepro equivs quilt
 
 # install golang
-RUN wget -O - "https://go.dev/dl/go1.22.9.linux-amd64.tar.gz" | tar -C /usr/local -xz
+RUN wget -O - "https://go.dev/dl/go1.22.12.linux-amd64.tar.gz" | tar -C /usr/local -xz
 
 COPY . /pxf_src/
 RUN apt -o Apt::Get::Assume-Yes=true install /pxf_src/downloads/greenplum-db-6_6.0.0-jammy-dev_amd64.deb
@@ -25,7 +25,8 @@ RUN locale-gen en_US.utf8
 
 # copy source & create layout for packaging
 ENV PXF_PKG_VERSION "6.10.1-jammy-dev"
-RUN cp -r /pxf_src/devops/packaging/deb/pxf_6_jammy/debian /pxf_src/debian \
+RUN mkdir -p /pxf_src/debian \
+ && cp -r /pxf_src/devops/packaging/pxf/deb/22.04/* /pxf_src/debian \
  && source /pxf_src/package/package-deb.bash \
  && print_changelog > /pxf_src/debian/changelog
 

--- a/package/pxf_cb_jammy/Dockerfile
+++ b/package/pxf_cb_jammy/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
         python3 devscripts debhelper pbuilder reprepro equivs quilt
 
 # install golang
-RUN wget -O - "https://go.dev/dl/go1.22.9.linux-amd64.tar.gz" | tar -C /usr/local -xz
+RUN wget -O - "https://go.dev/dl/go1.22.12.linux-amd64.tar.gz" | tar -C /usr/local -xz
 
 # install greenplum:
 COPY . /pxf_src/
@@ -27,7 +27,8 @@ RUN locale-gen en_US.utf8
 # copy source & create layout for packaging
 ENV PXF_PKG_VERSION "1.0.0-jammy-dev"
 COPY . /packaging/
-RUN cp -r /pxf_src/devops/packaging/deb/pxf_cb_jammy/debian /pxf_src/debian \
+RUN mkdir -p /pxf_src/debian \
+ && cp -r /pxf_src/devops/packaging/pxf/deb/22.04-cbdb/* /pxf_src/debian \
  && source /pxf_src/package/package-deb.bash \
  && print_cb_changelog > /pxf_src/debian/changelog
 


### PR DESCRIPTION
Update paths to `debian` files to keep up open-gpdb/gpdb-devops

gpdb-devops changes: https://github.com/open-gpdb/gpdb-devops/pull/34