### PR TITLE
Fix greenplum_path.sh usage for Cloudberry

### DIFF
--- a/package/pxf_cb_jammy/Dockerfile
+++ b/package/pxf_cb_jammy/Dockerfile
@@ -43,7 +43,7 @@ RUN mk-build-deps  --build-dep --install --tool='apt-get -o Debug::pkgProblemRes
 
 
 # dpkg-buildpackage will call make && make install (via debian/rules)
-RUN source /usr/cloudberry-db/greenplum_path.sh \
+RUN source /usr/cloudberry-db/cloudberry-env.sh \
  && PATH="/usr/local/go/bin:$PATH" \
     GPHOME="/usr/cloudberry-db" \
     PXF_HOME="/pxf_src/debian/build/gp/pxf" \


### PR DESCRIPTION
### Cloudberry

Cloudberry replaced `greenplum_path.sh` to `cloudberry-env.sh` due to legal reasons:
https://github.com/apache/cloudberry/pull/1166

So, we should use correct scripts. Otherwise tests fails:
```
Run make -C package deb-pxf6-cbdb-jammy
<...>
> [12/13] RUN source /usr/cloudberry-db/greenplum_path.sh  && PATH="/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"     GPHOME="/usr/cloudberry-db"     PXF_HOME="/pxf_src/debian/build/gp/pxf"     JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"     dpkg-buildpackage -us -uc:
0.117 /bin/bash: line 1: /usr/cloudberry-db/greenplum_path.sh: No such file or directory
```